### PR TITLE
Improve docker-compose configuration according to best practices:

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The project consists of three main parts:
 Spin up a Spline server in a Docker
 
 ```shell
-wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/docker-compose.yml
+wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/compose.yaml
 
 wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/.env
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@ This docker-compose config is designed to start all Spline Docker components in 
 It's especially useful for trying out and demo purposes.
 
 ```shell
-wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/docker-compose.yml
+wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/compose.yaml
 
 wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/.env
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -26,21 +26,13 @@ services:
     restart: on-failure
     ports:
       - ${SPLINE_REST_PORT}:8080
-    command: >
-      bash -c "
-        until curl --output /dev/null --silent --get --fail http://arangodb:8529/_db/spline/_admin/server/availability
-        do
-          echo waiting for Spline database to be ready...
-          sleep 5
-        done
-        catalina.sh run
-      "
     environment:
       SPLINE_DATABASE_CONNECTION_URL: 'arangodb://arangodb/spline'
       # by default /dev/random is used which may block
       CATALINA_OPTS: "-Dsecurerandom.source=file:/dev/./urandom -Djava.security.egd=file:/dev/./urandom"
     depends_on:
-      - arangodb
+      db-init:
+        condition: service_completed_successfully
 
   db-init:
     image: absaoss/spline-admin:${SPLINE_CORE_VERSION}

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,63 +1,71 @@
+#  Copyright 2019 ABSA Group Limited
+#
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 ---
-version: '3'
+name: 'spline-demo'
 services:
   arangodb:
     image: arangodb:${ARANGO_DB_VERSION}
     restart: on-failure
     ports:
       - ${ARANGO_DB_PORT}:8529
-    network_mode: "bridge"
     environment:
       ARANGO_NO_AUTH: 1
 
-  spline:
+  rest-server:
     image: absaoss/spline-rest-server:${SPLINE_CORE_VERSION}
     restart: on-failure
     ports:
       - ${SPLINE_REST_PORT}:8080
-    network_mode: "bridge"
     command: >
       bash -c "
-        until curl --output /dev/null --silent --get --fail http://172.17.0.1:${ARANGO_DB_PORT}/_db/spline/_admin/server/availability
+        until curl --output /dev/null --silent --get --fail http://arangodb:8529/_db/spline/_admin/server/availability
         do
-          echo waiting for 'spline' database to be ready
+          echo waiting for Spline database to be ready...
           sleep 5
         done
         catalina.sh run
       "
     environment:
-      SPLINE_DATABASE_CONNECTION_URL: 'arangodb://172.17.0.1:${ARANGO_DB_PORT}/spline'
+      SPLINE_DATABASE_CONNECTION_URL: 'arangodb://arangodb/spline'
       # by default /dev/random is used which may block
       CATALINA_OPTS: "-Dsecurerandom.source=file:/dev/./urandom -Djava.security.egd=file:/dev/./urandom"
-    links:
+    depends_on:
       - arangodb
 
-  spline-init-db:
+  db-init:
     image: absaoss/spline-admin:${SPLINE_CORE_VERSION}
     restart: on-failure
-    network_mode: "bridge"
     entrypoint: >
       tini -g -- bash -c "
-        until curl --output /dev/null --silent --get --fail http://172.17.0.1:${ARANGO_DB_PORT}/_admin/server/availability
+        until curl --output /dev/null --silent --get --fail http://arangodb:8529/_admin/server/availability
         do
-          echo waiting for ArangoDB server to be ready
+          echo waiting for ArangoDB server to be ready...
           sleep 5
         done
-        bash ./entrypoint.sh db-init arangodb://172.17.0.1:${ARANGO_DB_PORT}/spline -s
+        bash ./entrypoint.sh db-init arangodb://arangodb/spline -s
       "
-    links:
+    depends_on:
       - arangodb
 
-  agent:
+  run-examples:
     image: absaoss/spline-spark-agent:${SPLINE_AGENT_VERSION}
-    network_mode: "bridge"
     command: >
       bash -c "
         if [ ! -z "$SEED" ]
         then
-          until curl --output /dev/null --silent --get --fail http://172.17.0.1:${SPLINE_REST_PORT}
+          until curl --output /dev/null --silent --get --fail http://rest-server:8080
           do
-            echo waiting for spline
+            echo waiting for Spline server to be ready...
             sleep 5
           done
           mvn test \\
@@ -71,9 +79,9 @@ services:
       "
     environment:
       SEED: ${SEED} # Controls if the agent examples should run on startup up
-      SPLINE_PRODUCER_URL: 'http://172.17.0.1:${SPLINE_REST_PORT}/producer'
-    links:
-      - spline
+      SPLINE_PRODUCER_URL: 'http://rest-server:8080/producer'
+    depends_on:
+      - rest-server
 
   ui:
     image: absaoss/spline-web-ui:${SPLINE_UI_VERSION}
@@ -85,5 +93,5 @@ services:
       CATALINA_OPTS: "-Dsecurerandom.source=file:/dev/./urandom -Djava.security.egd=file:/dev/./urandom"
     ports:
       - ${SPLINE_UI_PORT}:8080
-    links:
-      - spline
+    depends_on:
+      - rest-server

--- a/spline-on-AWS-demo-setup/README.md
+++ b/spline-on-AWS-demo-setup/README.md
@@ -101,7 +101,7 @@ Download Spline demo Docker-compose config files:
 mkdir spline
 cd spline
 
-wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/docker-compose.yml
+wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/compose.yaml
 wget https://raw.githubusercontent.com/AbsaOSS/spline-getting-started/main/docker/.env
 ```
 
@@ -113,7 +113,7 @@ DOCKER_HOST_EXTERNAL=18.116.202.35 docker-compose up
 ```
 
 The given Docker Compose config also runs a set of Spark examples to pre-populate the database. You can either ignore them, or disable them by
-commenting out the `agent` service block in the `docker-compose.yml` file:
+commenting out the `agent` service block in the `compose.yaml` file:
 
 ```yaml
 


### PR DESCRIPTION
- Rename `docker-compose.yml` to `compose.yaml`
- Remove `version` top-level element
- Add `name` top-level element
- Replace `links` with `depends_on`
- Rename some services for clarity
- Services (except for UI) to communicate via hostnames and on the internal network, not to be routed via the host.

Thanks @korbelm for hints